### PR TITLE
Fixing error with players not properly connected

### DIFF
--- a/SCPSLAudioApi/AudioCore/AudioPlayerBase.cs
+++ b/SCPSLAudioApi/AudioCore/AudioPlayerBase.cs
@@ -386,7 +386,7 @@ namespace SCPSLAudioApi.AudioCore
 
         private bool PlayerIsConnected(ReferenceHub hub)
         {
-            return hub.characterClassManager.InstanceMode != ClientInstanceMode.Unverified && hub.nicknameSync.NickSet;
+            return hub.characterClassManager.InstanceMode == ClientInstanceMode.ReadyClient && hub.nicknameSync.NickSet;
         }
     }
 }

--- a/SCPSLAudioApi/AudioCore/AudioPlayerBase.cs
+++ b/SCPSLAudioApi/AudioCore/AudioPlayerBase.cs
@@ -377,11 +377,16 @@ namespace SCPSLAudioApi.AudioCore
                 
                 foreach (var plr in ReferenceHub.AllHubs)
                 {
-                    if (plr.connectionToClient == null || (BroadcastTo.Count >= 1 && !BroadcastTo.Contains(plr.PlayerId))) continue;
+                    if (plr.connectionToClient == null || !PlayerIsConnected(plr) || (BroadcastTo.Count >= 1 && !BroadcastTo.Contains(plr.PlayerId))) continue;
                     
                     plr.connectionToClient.Send(new VoiceMessage(Owner, BroadcastChannel, EncodedBuffer, dataLen, false));
                 }
             }
+        }
+
+        private bool PlayerIsConnected(Reference hub)
+        {
+            return hub.characterClassManager.InstanceMode != ClientInstanceMode.Unverified && hub.nicknameSync.NickSet;
         }
     }
 }

--- a/SCPSLAudioApi/AudioCore/AudioPlayerBase.cs
+++ b/SCPSLAudioApi/AudioCore/AudioPlayerBase.cs
@@ -384,7 +384,7 @@ namespace SCPSLAudioApi.AudioCore
             }
         }
 
-        private bool PlayerIsConnected(Reference hub)
+        private bool PlayerIsConnected(ReferenceHub hub)
         {
             return hub.characterClassManager.InstanceMode != ClientInstanceMode.Unverified && hub.nicknameSync.NickSet;
         }


### PR DESCRIPTION
If a player is connecting to the server and the bot is playing audio, this may cause the player to never connect to the server due to an error of
```cs
Unknown message id: 45878. This can happen if no handler was registered for this message.
NetworkClient: failed to unpack and invoke message. Disconnecting.
InvalidOperationException: Queue empty.
  at System.Collections.Generic.Queue`1[T].ThrowForEmptyQueue () [0x00000] in <00000000000000000000000000000000>:0 
  at System.Collections.Generic.Queue`1[T].Dequeue () [0x00000] in <00000000000000000000000000000000>:0 
  at LiteNetLib.NetManager.PollEvents () [0x00000] in <00000000000000000000000000000000>:0
```
This can also crash the player
